### PR TITLE
Implement tenant structure for multi-company use

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -290,18 +290,9 @@ public class AccountController : ControllerBase
     [HttpPost("register")]
     public async Task<IActionResult> Register([FromBody] RegisterModel model)
     {
-        var isFirstUser = !await _userManager.Users.AnyAsync();
-
-        var user = new ApplicationUser { UserName = model.Email, Email = model.Email };
-        var result = await _userManager.CreateAsync(user, model.Password);
-
-        if (!result.Succeeded)
-            return BadRequest(result.Errors);
-
-        var role = isFirstUser ? "Admin" : "User";
-        await _userManager.AddToRoleAsync(user, role);
-
-        return Ok("User registered successfully.");
+        // Disable bare registration to enforce company-first onboarding.
+        // Use POST /companies/register to create a company and its Admin, then Admin invites users.
+        return Forbid();
     }
 
     [HttpPost("login")]

--- a/Controllers/GoogleAuthController.cs
+++ b/Controllers/GoogleAuthController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
@@ -57,17 +57,10 @@ public class GoogleAccountController : ControllerBase
         }
         else
         {
+            // Do NOT auto-provision new users via Google. Only allow sign-in for existing invited users.
             user = await _userManager.FindByEmailAsync(email);
-            var isFirstUser = !await _userManager.Users.AnyAsync();
-
             if (user == null)
-            {
-                user = new ApplicationUser { UserName = email, Email = email };
-                var createResult = await _userManager.CreateAsync(user);
-                if (!createResult.Succeeded) return BadRequest(createResult.Errors);
-
-                await _userManager.AddToRoleAsync(user, isFirstUser ? "Admin" : "User");
-            }
+                return Forbid();
 
             var addLoginResult = await _userManager.AddLoginAsync(user, info);
             if (!addLoginResult.Succeeded) return BadRequest(addLoginResult.Errors);

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -20,6 +20,20 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
         base.OnModelCreating(builder);
 
+        // Foreign keys and indexes for tenant integrity
+        builder.Entity<ApplicationUser>()
+            .HasIndex(u => u.CompanyId);
+
+        builder.Entity<Company>()
+            .HasIndex(c => c.Name)
+            .IsUnique(false);
+
+        builder.Entity<Project>()
+            .HasIndex(p => p.CompanyId);
+
+        builder.Entity<InventoryItem>()
+            .HasIndex(i => i.CompanyId);
+
         // Global query filters for tenant isolation
         // Do NOT filter ApplicationUser globally to avoid breaking login and admin flows.
         var companyId = _tenantProvider?.CompanyId ?? 0;

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -4,12 +4,27 @@ using ErpApi;
 
 public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 {
-    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+    private readonly ITenantProvider? _tenantProvider;
+
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, ITenantProvider? tenantProvider = null)
         : base(options)
     {
+        _tenantProvider = tenantProvider;
     }
 
     public DbSet<Project> Projects => Set<Project>();
     public DbSet<Company> Companies => Set<Company>();
     public DbSet<InventoryItem> InventoryItems => Set<InventoryItem>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        // Global query filters for tenant isolation
+        // Do NOT filter ApplicationUser globally to avoid breaking login and admin flows.
+        var companyId = _tenantProvider?.CompanyId ?? 0;
+
+        builder.Entity<Project>().HasQueryFilter(p => companyId == 0 || p.CompanyId == companyId);
+        builder.Entity<InventoryItem>().HasQueryFilter(i => companyId == 0 || i.CompanyId == companyId);
+    }
 }

--- a/Helpers/TenantProvider.cs
+++ b/Helpers/TenantProvider.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+public interface ITenantProvider
+{
+    int CompanyId { get; }
+}
+
+public class HttpContextTenantProvider : ITenantProvider
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public HttpContextTenantProvider(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public int CompanyId
+    {
+        get
+        {
+            var user = _httpContextAccessor.HttpContext?.User;
+            if (user is null) return 0;
+
+            var claimValue = user.FindFirst("companyId")?.Value;
+            return int.TryParse(claimValue, out var id) ? id : 0;
+        }
+    }
+}
+

--- a/Program.cs
+++ b/Program.cs
@@ -116,6 +116,8 @@ namespace ErpApi
             });
 
             builder.Services.AddScoped<JwtTokenHelper>();
+            builder.Services.AddHttpContextAccessor();
+            builder.Services.AddScoped<ITenantProvider, HttpContextTenantProvider>();
 
             var app = builder.Build();
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,21 @@ The goal of this ERP system is to provide a **centralized platform** that improv
 
 ---
 
-## Getting Started
-Clone the repository and follow the setup instructions in the documentation (to be added).  
-```bash
-git clone https://github.com/your-username/your-repo-name.git
+## Onboarding Flow (Multi-tenant)
+
+1. Register a company and bootstrap its Admin:
+   - POST `companies/register` with `{ name, adminEmail, adminPassword }`
+   - Response includes a JWT for the Admin. This Admin is scoped to the new company.
+
+2. Admin adds users to their company:
+   - POST `account/users` (with password) or `account/users/basic` (no password)
+   - New users are automatically assigned to the Admin's `companyId`.
+
+3. Admin invites user to activate:
+   - POST `account/users/{userId}/invite` to generate activation (email confirm + reset) tokens
+   - User completes activation via POST `account/activate` with tokens and sets their password
+
+Notes:
+- Public "bare" registration is disabled. Use `companies/register` to create tenants.
+- Google OAuth sign-in is allowed only for existing users; it will not auto-create accounts.
+- All data access is tenant-scoped via JWT `companyId` claim and EF Core global query filters.


### PR DESCRIPTION
Implement multi-tenancy using EF Core global query filters to isolate `Project` and `InventoryItem` data by `CompanyId`.

This enables the product owner to sell the product to other companies, ensuring each company's data is isolated. The existing application structure, including `Company` entities and `companyId` in JWTs, allowed for a `TenantProvider` to extract the current user's company and apply global query filters for automatic data scoping.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fd61882-9ad8-4cef-a76e-2beb6d12fe6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fd61882-9ad8-4cef-a76e-2beb6d12fe6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

